### PR TITLE
Fallback to knife.rb for Chef Server configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changes
 Next Version
 --
 
+FEATURES:
+
+* Fallback to *knife.rb* for Chef Server configuration
+
 FIXES:
 
 * Detect when inspectors are not configured at all

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ $ kitchen-inspector --config config_example.rb
 
 ### Chef server
 
+When a valid Chef Server configuration is not specified it fallbacks to *${HOME}/.chef/knife.rb*, if present.
+
 Example:
 
 ```ruby

--- a/spec/health_bureau_spec.rb
+++ b/spec/health_bureau_spec.rb
@@ -1,6 +1,13 @@
 require_relative 'support/spec_helper'
 
 describe HealthBureau do
+  before(:each) do
+    # Ignore existing knife.rb configuration
+    orig_file = File.method(:exists?)
+    File.stub(:exists?).with(anything()) { |*args| orig_file.call(*args) }
+    File.stub(:exists?).with("#{Dir.home}/.chef/knife.rb").and_return(false)
+  end
+
   let(:health_bureau) { generate_health_bureau }
 
   let(:repomanager_info) do


### PR DESCRIPTION
Use knife.rb when a configuration for chef_server is not specified.
Closes #1
